### PR TITLE
feat(replaceOuter) : Added replaceOuter property to replace the data-loc tag with the remote content or fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The ConvergentUIFilter scans HTML coming across the Proxy for content enriched w
 | `data-fragment-name` | A unique name of a fragment of the content provided by the data-loc. This allows you to request an entire HTML page and only include a section of that page that contains a `data-fragment-name` that matches this name.  |
 | `data-fail-quietly` | If true and a failure occurs, the content section will be replaced with an empty `<div class='cui-error'>`. If false, the content section will be replaced with an error message inside a `<span class='cui-error'></span>` |
 | `data-disable-caching` | If you would like to disable caching for this location, set this to true |
+| `data-replace-outer` | If true, the `data-loc` tag will be replaced by the remote content or fragment (true by default in order to keep final HTML clean) |
 
 An example section of HTML follows:
 

--- a/src/main/java/net/acesinc/convergentui/ConvergentUIResponseFilter.java
+++ b/src/main/java/net/acesinc/convergentui/ConvergentUIResponseFilter.java
@@ -55,6 +55,7 @@ public class ConvergentUIResponseFilter extends BaseResponseFilter {
                 String cacheName = e.dataset().get("cache-name");
                 boolean useCaching = !Boolean.valueOf(e.dataset().get("disable-caching"));
                 boolean failQuietly = Boolean.valueOf(e.dataset().get("fail-quietly"));
+                boolean replaceOuter = e.dataset().get("replace-outer") == null ? true : Boolean.valueOf(e.dataset().get("replace-outer"));
                 URL url = null;
                 try {
                     url = new URL(location);
@@ -140,6 +141,11 @@ public class ConvergentUIResponseFilter extends BaseResponseFilter {
                         }
                         log.warn("Failed replacing content", t);
                     }
+                    
+                    if(replaceOuter) {
+						// outer element should be replaced by content
+						e.unwrap();
+					}
                 } catch (MalformedURLException ex) {
                     log.warn("location was invalid: [ " + location + " ]", ex);
                     if (!failQuietly) {


### PR DESCRIPTION
This simple feature allows to replace the 'data-loc' tag with the remote content or fragment by default. If property is set to 'true', the actual behaviour is adopter (ie : include content into div tag).

That way, the final HTML will be clean of non necessary tags.

Ex :

Let's say that page-header-app is responsible to generate the following header html content :

```
<header>
   <div>...<div>
</header>
```

The page includes the header content using data-loc :

```
<html>
   <body>
      <div data-loc="http://page-header-app" />
   </body>
</html>
```

The old way of working will produce :

```
<html>
   <body>
      <div data-loc="http://page-header-app">
         <header>
            <div>...<div>
         </header>
      </div>
   </body>
</html>
```

The new way of working will now produce this cleaned result by default :

```
<html>
   <body>
      <header>
         <div>...<div>
      </header>
   </body>
</html>
```
